### PR TITLE
Allow integrators to specify a resource for additional logos

### DIFF
--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -66,6 +66,7 @@ class SocialBookmarksBase(object):
         filtered and populated.
         """
         context = aq_inner(self.context)
+        portal_url = getToolByName(context, 'portal_url')()
         available = self._availableProviders()
         providers = []
         # Attributes available to be substituted in the URL
@@ -85,6 +86,14 @@ class SocialBookmarksBase(object):
                 continue
             url_tmpl = re.sub(pattern, r'${\1}', url_tmpl)
             provider['url'] = Template(url_tmpl).safe_substitute(param)
+
+            resource_name = provider.get('resource', 'sb_images')
+            logo = provider.get('logo', '')
+            provider['icon_url'] = '%s/++resource++%s/%s' % (
+                portal_url,
+                resource_name,
+                logo
+            )
             providers.append(provider)
         return providers
 

--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -1,29 +1,25 @@
 # -*- coding: utf-8 -*-
+import logging
 import re
 from string import Template
 
 from Acquisition import aq_inner
 from Acquisition import Explicit
-
+from Products.CMFCore.utils import getToolByName
 from zope.interface import Interface
 from zope.interface import implements
-
 from zope.component import adapts
 from zope.component import getUtility
-
 from zope.contentprovider.interfaces import IContentProvider
-
 from zope.publisher.interfaces.browser import IBrowserRequest
 from zope.publisher.interfaces.browser import IBrowserView
-
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
 from plone.app.layout.viewlets import ViewletBase
 from plone.memoize.view import memoize
 from plone.registry.interfaces import IRegistry
 
-from sc.social.bookmarks.controlpanel.bookmarks import IProvidersSchema
+from ..controlpanel.bookmarks import IProvidersSchema
 
 
 class SocialBookmarksBase(object):

--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -54,11 +54,7 @@ class SocialBookmarksBase(object):
             provider = all_providers.get(bookmark_id, None)
             if not provider:
                 continue
-            logo = provider.get('logo', '')
-            url = provider.get('url', '')
-            providers.append({'id': bookmark_id,
-                              'logo': logo,
-                              'url': url})
+            providers.append(provider)
 
         return providers
 

--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -31,7 +31,7 @@ class SocialBookmarksBase(object):
 
     @memoize
     def _all_providers(self):
-        ''' Return a dict with all providers '''
+        """ Return a dict with all providers """
         reg = self._registry()
         providers = [reg[k] for k in reg.records.keys()
                      if k.startswith('sc.social.bookmarks.providers')]
@@ -69,10 +69,12 @@ class SocialBookmarksBase(object):
         context = aq_inner(self.context)
         available = self._availableProviders()
         providers = []
-        param = {}
-        param['title'] = context.Title()
-        param['description'] = context.Description()
-        param['url'] = context.absolute_url()
+        # Attributes available to be substituted in the URL
+        param = {
+            'title': context.Title(),
+            'description': context.Description(),
+            'url': context.absolute_url()
+        }
         # BBB: Instead of using string formatting we moved to string Templates
         pattern = re.compile("\%\(([a-zA-Z]*)\)s")
         for provider in available:

--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -22,6 +22,9 @@ from zope.publisher.interfaces.browser import IBrowserView
 from ..controlpanel.bookmarks import IProvidersSchema
 
 
+logger = logging.getLogger(__name__)
+
+
 class SocialBookmarksBase(object):
     """Abstract Base class for social bookmarks.
     """
@@ -75,7 +78,10 @@ class SocialBookmarksBase(object):
         pattern = re.compile("\%\(([a-zA-Z]*)\)s")
         for provider in available:
             url_tmpl = provider.get('url', '').strip()
-            if not(url_tmpl):
+            logo = provider.get('logo', '')
+            if not url_tmpl or not logo:
+                # A provider must have a logo and a share URL
+                logger.error('Provider %s has not URL or logo specified', provider['id'])
                 continue
             url_tmpl = re.sub(pattern, r'${\1}', url_tmpl)
             provider['url'] = Template(url_tmpl).safe_substitute(param)

--- a/src/sc/social/bookmarks/browser/common.py
+++ b/src/sc/social/bookmarks/browser/common.py
@@ -6,18 +6,18 @@ from string import Template
 from Acquisition import aq_inner
 from Acquisition import Explicit
 from Products.CMFCore.utils import getToolByName
-from zope.interface import Interface
-from zope.interface import implements
-from zope.component import adapts
-from zope.component import getUtility
-from zope.contentprovider.interfaces import IContentProvider
-from zope.publisher.interfaces.browser import IBrowserRequest
-from zope.publisher.interfaces.browser import IBrowserView
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.viewlets import ViewletBase
 from plone.memoize.view import memoize
 from plone.registry.interfaces import IRegistry
+from zope.component import adapts
+from zope.component import getUtility
+from zope.contentprovider.interfaces import IContentProvider
+from zope.interface import Interface
+from zope.interface import implements
+from zope.publisher.interfaces.browser import IBrowserRequest
+from zope.publisher.interfaces.browser import IBrowserView
 
 from ..controlpanel.bookmarks import IProvidersSchema
 

--- a/src/sc/social/bookmarks/browser/templates/bookmarks.pt
+++ b/src/sc/social/bookmarks/browser/templates/bookmarks.pt
@@ -13,7 +13,7 @@
       <a href="" title="" tal:attributes="href provider/url;
                                           title string:${provider/id}">
         <img src=""
-             tal:attributes="src string:${portal_url}/++resource++sb_images/${provider/logo};
+             tal:attributes="src provider/icon_url;
                              alt string:${provider/id}" />
         <span class="bookmark_id"
               tal:condition="not:icons_only"


### PR DESCRIPTION
Allows integrators to specify a resource for the logo of any additional bookmark providers.

Currently integrators can add additional social bookmark providers via XML, however the logo must be within the sc.social.bookmarks egg's image resource.

This change allows integrators to specify an optional resource field to their XML allowing the egg to lookup the logo from another defined resource